### PR TITLE
post Tags working correctly

### DIFF
--- a/src/components/posts/MyPosts.js
+++ b/src/components/posts/MyPosts.js
@@ -23,10 +23,19 @@ export const MyPosts = () => {
     const deletePost = (evt) => {
 
         return fetch(`http://localhost:8000/posts/${evt.target.value}`, {
-            method: "DELETE"
+            method: "DELETE",
+            headers: {
+                "Authorization": `Token ${localStorage.getItem("auth_token")}`
+
+            }
         })
             .then(() => {
-                fetch(`http://localhost:8000/posts`)
+                fetch(`http://localhost:8000/posts?mine`,
+                {
+                    headers: {
+                        "Authorization": `Token ${localStorage.getItem("auth_token")}`
+                    }
+                })
                     .then(response => response.json())
                     .then((postArray) => {
                         setMyPosts(postArray)

--- a/src/components/posts/postDetails.js
+++ b/src/components/posts/postDetails.js
@@ -24,7 +24,7 @@ export const PostDetails = () => {
     return <div className="postBox">
         <div className="postTitle">{post?.title}</div>
         <img className="postImage" src={post?.image_url} alt=""></img>
-        <Link to={`/users/${post?.user?.id}`} className="author">Author: {post?.user?.first_name} {post?.user?.last_name}</Link>
+        <Link to={`/users/${post?.author?.id}`} className="author">Author: {post?.user?.first_name} {post?.user?.last_name}</Link>
         <div className="postDate">Publication Date: {post?.publication_date} </div>
         <div className="postCategory"> Category: {post?.category?.label}</div>
         <div>Content: {post?.content} </div>

--- a/src/components/posts/postForm.js
+++ b/src/components/posts/postForm.js
@@ -81,6 +81,7 @@ export const PostForm = () => {
 
                 postId = updatedPost.id
                 
+                debugger
                 checked.map(check => {
                     const postTagsToSendToAPI = {
                         post_id: updatedPost.id,
@@ -197,13 +198,13 @@ export const PostForm = () => {
         <fieldset>
             {
                 tags.map(tag => <>
-                <input type="checkbox" id="tag" name="tag" value={tag.id}
+                <input type="checkbox" id={tag.id} name={tag.id} value={tag.id}
                 onChange = {
                     (evt) => {
                         handleCheck(evt)
                     }
                 }/>
-                <label htmlFor="tag" value={tag.id}>{tag.label}</label>
+                <label htmlFor={tag.id} value={tag.id}>{tag.label}</label>
                 </>
                 )
             }


### PR DESCRIPTION
modified logic to make post tags work correctly. Deletes all post tags and recreates them from which ones were selected. Was getting "server busy" before when we were trying to use a loop and send multiple fetches to add/delete one by one, now sending all at the same time and handling on server side